### PR TITLE
Remove the search plugin from the configuration

### DIFF
--- a/betty.yaml
+++ b/betty.yaml
@@ -15,7 +15,6 @@ plugins:
   betty.plugins.wikipedia.Wikipedia: {}
   betty.plugins.maps.Maps: {}
   betty.plugins.trees.Trees: {}
-  betty.plugins.search.Search: {}
   ancestry.plugins.PublishBart: {}
   ancestry.plugins.PopulateBart: {}
   betty.plugins.nginx.Nginx:


### PR DESCRIPTION
Remove the search plugin from the configuration, as it is now rendered by default.